### PR TITLE
Fix issue where BorderRadius? can't be nullable

### DIFF
--- a/lib/skeleton_text.dart
+++ b/lib/skeleton_text.dart
@@ -67,7 +67,7 @@ class _SkeletonAnimationState extends State<SkeletonAnimation>
                 .getProperties()
                 .where((element) => element.name == "margin")),
             child: ClipRRect(
-              borderRadius: widget.borderRadius as BorderRadius?,
+              borderRadius: widget.borderRadius,
               child: AnimatedBuilder(
                 animation: _controller,
                 builder: (BuildContext context, Widget? child) {


### PR DESCRIPTION
This is currently breaking for Flutter 3.13 (current stable version).